### PR TITLE
Add AppVeyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,39 @@
+image: Visual Studio 2017
+
+configuration:
+  - Release
+  - Debug
+
+platform:
+  - x64
+  - Win32
+
+environment:
+  # VS VERSION IN CMAKE STYLE
+  matrix:
+    - VSVERSION: "15 2017"
+    - VSVERSION: "14 2015"
+    - VSVERSION: "12 2013"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+matrix:
+  exclude:
+    - VSVERSION: "12 2013"
+      platform: x64
+    - VSVERSION: "12 2013"
+      configuration: Debug
+
+init:
+  - cmake --version
+  - msbuild /version
+
+before_build:
+  - if "%platform%"=="Win32" ( set "CMAKE_GENERATOR_NAME=Visual Studio %VSVERSION%" )
+  - if "%platform%"=="x64" ( set "CMAKE_GENERATOR_NAME=Visual Studio %VSVERSION% Win64")
+  - mkdir build
+  - cd build
+  - cmake -G "%CMAKE_GENERATOR_NAME%" ..
+
+build:
+  project: "build\\winflexbison.sln"
+  parallel: false


### PR DESCRIPTION
Testing for different VS version is hard/not possible for @lexxmark locally. So let's change this by adding a continuous integration platform and automate this 😄 

This generates the following build matrix:

[VS2015, VS2017] x [x64, Win32] x [Release, Debug]  +  [VS2013 Release win32]

You can see the results here:

https://ci.appveyor.com/project/Croydon/winflexbison/build/1.0.6

AppVeyor is completely free for open source projects. You need to activate AppVeyor before merging this. To do this go to https://ci.appveyor.com login with out GitHub account and enable the winflexbison project.

Happy testing! 😄 

