### PR TITLE
custom_build_rules bison: adjust outputfile to include defines file

### DIFF
--- a/custom_build_rules/win_bison_only/win_bison_custom_build.props
+++ b/custom_build_rules/win_bison_only/win_bison_custom_build.props
@@ -16,7 +16,7 @@
       <CommandLineTemplate>
 start /B /WAIT /D "%(RootDir)%(Directory)" win_bison.exe [AllOptions] [AdditionalOptions] "%(Filename)%(Extension)"
 exit /b %errorlevel%</CommandLineTemplate>
-      <Outputs>%(RootDir)%(Directory)%(OutputFile);</Outputs>
+      <Outputs>%(RootDir)%(Directory)%(OutputFile);%(RootDir)%(Directory)%(DefinesFile);</Outputs>
       <ExecutionDescription>Process "%(Filename)%(Extension)" bison file</ExecutionDescription>
     </Bison>
   </ItemDefinitionGroup>

--- a/custom_build_rules/win_flex_bison/win_flex_bison_custom_build.props
+++ b/custom_build_rules/win_flex_bison/win_flex_bison_custom_build.props
@@ -16,7 +16,7 @@
       <CommandLineTemplate>
 start /B /WAIT /D "%(RootDir)%(Directory)" win_bison.exe [AllOptions] [AdditionalOptions] "%(Filename)%(Extension)"
 exit /b %errorlevel%</CommandLineTemplate>
-      <Outputs>%(RootDir)%(Directory)%(OutputFile);</Outputs>
+      <Outputs>%(RootDir)%(Directory)%(OutputFile);%(RootDir)%(Directory)%(DefinesFile);</Outputs>
       <ExecutionDescription>Process "%(Filename)%(Extension)" bison file</ExecutionDescription>
     </Bison>
   </ItemDefinitionGroup>


### PR DESCRIPTION
done as PR as I wasn't 100% sure if the missing output file was "by design"