### PR TITLE
CMake: allow using win_bison in-build

### DIFF
--- a/bison/CMakeLists.txt
+++ b/bison/CMakeLists.txt
@@ -21,6 +21,9 @@ list(REMOVE_ITEM SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/scan-skel.c")
 add_executable(${PROJECT_NAME} 
    ${SOURCE_FILES}
 )
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/data" "$<TARGET_FILE_DIR:${PROJECT_NAME}>/data"
+)
 
 target_include_directories(${PROJECT_NAME} PRIVATE "src")
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
Copies the data directory into the build path, so projects that embed winflexbison can call "win_bison" directly from its place in the build tree.