### PR TITLE
CMake: make winflexbison easier to use as a subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,7 @@ if(NOT MSVC)
    message( FATAL_ERROR "Visual Studio Build supported only" )
 endif()
 
-# Output Variables
-set(OUTPUT_DEBUG "${CMAKE_CURRENT_LIST_DIR}/bin/Debug")
-set(OUTPUT_RELEASE "${CMAKE_CURRENT_LIST_DIR}/bin/Release")
-
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${OUTPUT_DEBUG}")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${OUTPUT_RELEASE}")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(-D_DEBUG)
@@ -28,26 +21,32 @@ if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "Build type not specified: Use Release by default.")
 endif()
 
-#------------------------------------------------------------------------
-# Static Windows Runtime
-#   Option to statically link to the Windows runtime. Maybe only 
-#   applies to WIN32/MSVC.
-#------------------------------------------------------------------------
-if (MSVC)
-    option( USE_STATIC_RUNTIME "Set ON to change /MD(DLL) to /MT(static)" OFF )
-    if (USE_STATIC_RUNTIME)
-        set(CompilerFlags
-            CMAKE_CXX_FLAGS
-            CMAKE_CXX_FLAGS_DEBUG
-            CMAKE_CXX_FLAGS_RELEASE
-            CMAKE_C_FLAGS
-            CMAKE_C_FLAGS_DEBUG
-            CMAKE_C_FLAGS_RELEASE
-            )
-        foreach(CompilerFlag ${CompilerFlags})
-            string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
-        endforeach()    
-        message(STATUS "Using /MT STATIC runtime")
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # Output Variables
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_CURRENT_LIST_DIR}/bin/Debug")
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_CURRENT_LIST_DIR}/bin/Release")
+
+    #------------------------------------------------------------------------
+    # Static Windows Runtime
+    #   Option to statically link to the Windows runtime. Maybe only
+    #   applies to WIN32/MSVC.
+    #------------------------------------------------------------------------
+    if (MSVC)
+        option( USE_STATIC_RUNTIME "Set ON to change /MD(DLL) to /MT(static)" OFF )
+        if (USE_STATIC_RUNTIME)
+            set(CompilerFlags
+                CMAKE_CXX_FLAGS
+                CMAKE_CXX_FLAGS_DEBUG
+                CMAKE_CXX_FLAGS_RELEASE
+                CMAKE_C_FLAGS
+                CMAKE_C_FLAGS_DEBUG
+                CMAKE_C_FLAGS_RELEASE
+                )
+            foreach(CompilerFlag ${CompilerFlags})
+                string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+            endforeach()
+            message(STATUS "Using /MT STATIC runtime")
+        endif ()
     endif ()
 endif ()
 
@@ -57,36 +56,37 @@ add_subdirectory(common)
 add_subdirectory(flex)
 add_subdirectory(bison)
 
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # CPACK
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+      install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/" DESTINATION "./")
+    else()
+      install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE}/" DESTINATION "./")
+    endif()
 
-# CPACK
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  install(DIRECTORY "bin/Debug/" DESTINATION "./")
-else()
-  install(DIRECTORY "bin/Release/" DESTINATION "./")
+    install(DIRECTORY "custom_build_rules/" DESTINATION "./custom_build_rules/")
+    install(DIRECTORY "bison/data/" DESTINATION "./data/")
+    install(FILES "flex/src/FlexLexer.h" DESTINATION "./")
+    install(FILES "changelog.md" DESTINATION "./")
+    install(FILES "README.md" DESTINATION "./")
+
+    set(PACKAGE_GENERATORS_DEFAULT ZIP)
+
+    set(CPACK_GENERATOR ${PACKAGE_GENERATORS_DEFAULT} CACHE STRING "List of CPack Generators which will be created by the 'PACKAGE' target. Default: ZIP")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Winflexbison - Flex and Bison for Windows")
+
+    set(ENV_VERSION "$ENV{WINFLEXBISON_VERSION}")
+    if(NOT ENV_VERSION)
+      set(CPACK_PACKAGE_VERSION "master" CACHE STRING "Complete version of the created package.")
+    else()
+      set(CPACK_PACKAGE_VERSION "${ENV_VERSION}" CACHE STRING "Complete version of the created package.")
+    endif()
+
+    set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+    set(CPACK_ARCHIVE_COMPONENT_INSTALL OFF)
+    set(CPACK_MONOLITHIC_INSTALL ON)
+
+    set(CPACK_PACKAGE_FILE_NAME "win_flex_bison-${CPACK_PACKAGE_VERSION}")
+
+    include(CPack)
 endif()
-
-install(DIRECTORY "custom_build_rules/" DESTINATION "./custom_build_rules/")
-install(DIRECTORY "bison/data/" DESTINATION "./data/")
-install(FILES "flex/src/FlexLexer.h" DESTINATION "./")
-install(FILES "changelog.md" DESTINATION "./")
-install(FILES "README.md" DESTINATION "./")
-
-set(PACKAGE_GENERATORS_DEFAULT ZIP)
-
-set(CPACK_GENERATOR ${PACKAGE_GENERATORS_DEFAULT} CACHE STRING "List of CPack Generators which will be created by the 'PACKAGE' target. Default: ZIP")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Winflexbison - Flex and Bison for Windows")
-
-set(ENV_VERSION "$ENV{WINFLEXBISON_VERSION}")
-if(NOT ENV_VERSION)
-  set(CPACK_PACKAGE_VERSION "master" CACHE STRING "Complete version of the created package.")
-else()
-  set(CPACK_PACKAGE_VERSION "${ENV_VERSION}" CACHE STRING "Complete version of the created package.")
-endif()
-
-set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
-set(CPACK_ARCHIVE_COMPONENT_INSTALL OFF)
-set(CPACK_MONOLITHIC_INSTALL ON)
-
-set(CPACK_PACKAGE_FILE_NAME "win_flex_bison-${CPACK_PACKAGE_VERSION}")
-
-include(CPack)

--- a/bison/CMakeLists.txt
+++ b/bison/CMakeLists.txt
@@ -25,4 +25,4 @@ add_executable(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} PRIVATE "src")
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_link_libraries(${PROJECT_NAME} common_lib kernel32.lib user32.lib)
+target_link_libraries(${PROJECT_NAME} winflexbison_common kernel32.lib user32.lib)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
 
-set(PROJECT_NAME common_lib)
+set(PROJECT_NAME winflexbison_common)
 
 project(${PROJECT_NAME} C)
 

--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -22,4 +22,4 @@ add_executable(${PROJECT_NAME}
 
 target_include_directories(${PROJECT_NAME} PRIVATE "src")
 
-target_link_libraries(${PROJECT_NAME} common_lib kernel32.lib user32.lib Ws2_32.lib)
+target_link_libraries(${PROJECT_NAME} winflexbison_common kernel32.lib user32.lib Ws2_32.lib)


### PR DESCRIPTION
If it's used as a subdirectory:
- doesn't change output directories
- doesn't set up install rules or CPack
- doesn't add USE_STATIC_RUNTIME global option

Also renamed `common_lib` to `winflexbison_common`