### PR TITLE
use explicitly the ANSI variant of GetModuleFileName

### DIFF
--- a/common/misc/app_path.c
+++ b/common/misc/app_path.c
@@ -5,7 +5,7 @@ static char app_path[APP_PATH_LEN+1];
 
 const char* get_app_path()
 {
-	DWORD res = GetModuleFileName(NULL, app_path, APP_PATH_LEN);
+	DWORD res = GetModuleFileNameA(NULL, app_path, APP_PATH_LEN);
 
 	if (res == 0 || res == APP_PATH_LEN)
 		return 0;


### PR DESCRIPTION
Without this, the tool will miscompile with -DUNICODE set.

This is e.g. the case in our Windows build enviroment.

And given this code will really not work with the unicode variant, because of the wrong type of characters, I think it makes sense to make this just explicit.

Btw., thanks a lot for your work on having flex + bison working on Windows, highly appreciated!