### PR TITLE
Fix build with VS2019

### DIFF
--- a/common/m4/output.c
+++ b/common/m4/output.c
@@ -17,7 +17,9 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
+#if defined (_MSC_VER) && _MSC_VER >= 1900
+#include <corecrt_io.h>
+#endif
 #include "m4.h"
 
 #include <limits.h>


### PR DESCRIPTION
Hello,

With VS2019, currently the following error is generated:

 [1/117] Building C object common\CMakeFiles\winflexbison_common.dir\m4\output.c.obj
  FAILED: common/CMakeFiles/winflexbison_common.dir/m4/output.c.obj 
C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt\corecrt_io.h(470): error C2375: 'dup_safer': redefinition; different linkage
  winflexbison\common\m4\lib\unistd-safer.h(20): note: see declaration of 'dup_safer'

Including corecrt_io.h before including m4, which redefines dup as dup_safer, resolves this issue.

-obhi