### PR TITLE
[cmake] Improve support using CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,5 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     #   applies to WIN32/MSVC.
     #------------------------------------------------------------------------
     if (MSVC)
+        add_compile_definitions("__extension__")
+        add_compile_options("/source-charset:utf-8")
         option( USE_STATIC_RUNTIME "Set ON to change /MD(DLL) to /MT(static)" OFF )
         if (USE_STATIC_RUNTIME)
             set(CompilerFlags

--- a/bison/CMakeLists.txt
+++ b/bison/CMakeLists.txt
@@ -4,9 +4,6 @@ set(PROJECT_NAME win_bison)
 
 project(${PROJECT_NAME} C)
 
-# Definition of Macros
-add_definitions(-D_CONSOLE)
-
 file(GLOB SOURCE_FILES
     "src/*.c"
     "src/*.h"
@@ -21,6 +18,10 @@ list(REMOVE_ITEM SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/scan-skel.c")
 add_executable(${PROJECT_NAME} 
    ${SOURCE_FILES}
 )
+
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE "_CONSOLE")
+
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/data" "$<TARGET_FILE_DIR:${PROJECT_NAME}>/data"
 )
@@ -29,3 +30,14 @@ target_include_directories(${PROJECT_NAME} PRIVATE "src")
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_link_libraries(${PROJECT_NAME} winflexbison_common kernel32.lib user32.lib)
+
+# liby
+file(GLOB liby_src
+    "lib/*.c"
+    "lib/*.h"
+)
+
+add_library(y STATIC ${liby_src})
+
+target_include_directories(y
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src/")

--- a/bison/lib/main.c
+++ b/bison/lib/main.c
@@ -1,0 +1,30 @@
+/* Yacc library main function.
+
+   Copyright (C) 2002, 2009-2013 Free Software Foundation, Inc.
+
+   This file is part of Bison, the GNU Compiler Compiler.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <config.h>
+#include <locale.h>
+
+int yyparse (void);
+
+int
+main (void)
+{
+  setlocale (LC_ALL, "");
+  return yyparse ();
+}

--- a/bison/lib/yyerror.c
+++ b/bison/lib/yyerror.c
@@ -1,0 +1,32 @@
+/* Yacc library error-printing function.
+
+   Copyright (C) 2002, 2009-2013 Free Software Foundation, Inc.
+
+   This file is part of Bison, the GNU Compiler Compiler.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <config.h>
+
+#include <stdio.h>
+
+int yyerror (char const *);
+
+int
+yyerror (char const *message)
+{
+  fputs (message, stderr);
+  fputc ('\n', stderr);
+  return 0;
+}

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(${PROJECT_NAME} STATIC
    ${SOURCE_FILES}
 )
 
+set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 90)
+
 target_include_directories(${PROJECT_NAME} PUBLIC "misc")
 target_include_directories(${PROJECT_NAME} PUBLIC "m4")
 target_include_directories(${PROJECT_NAME} PUBLIC "m4/lib")

--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -4,9 +4,6 @@ set(PROJECT_NAME win_flex)
 
 project(${PROJECT_NAME} C)
 
-# Definition of Macros
-add_definitions(-D_CONSOLE)
-
 file(GLOB SOURCE_FILES
     "src/*.c"
     "src/*.h"
@@ -20,6 +17,17 @@ add_executable(${PROJECT_NAME}
    ${SOURCE_FILES}
 )
 
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE "_CONSOLE")
+
 target_include_directories(${PROJECT_NAME} PRIVATE "src")
 
 target_link_libraries(${PROJECT_NAME} winflexbison_common kernel32.lib user32.lib Ws2_32.lib)
+
+# libfl
+add_library(fl STATIC 
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/libmain.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/libyywrap.c")
+
+target_include_directories(fl
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src/")


### PR DESCRIPTION
1. Add **libfl**, **liby** support
2. Supporting adding this project as a cmake target dependency
3. Fix build problems related to C_STANDARD when using newer MSVC compiler

For how to use as a CMake dependency, see this example: [xy-compiler](https://github.com/LonghronShen/xy-compiler/tree/feature/runtime)