### PR TITLE
change file format from utf-8 to utf-8 BOM

### DIFF
--- a/bison/src/print-graph.c
+++ b/bison/src/print-graph.c
@@ -1,4 +1,4 @@
-/* Output a graph of the generated parser, for Bison.
+﻿/* Output a graph of the generated parser, for Bison.
 
    Copyright (C) 2001-2007, 2009-2015, 2018-2020 Free Software
    Foundation, Inc.


### PR DESCRIPTION
 change file encoding from utf-8 to utf-8 BOM to suppress c4819 warning. VS2019 have trouble to parse  "•" in obstack_sgrow (oout, "•"); it generate c4819 warning and following build errors.