### PR TITLE
Readme: Show status badge of the check-runs of the default git branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/58lcjnr0mb9uc8c8/branch/master?svg=true)](https://ci.appveyor.com/project/lexxmark/winflexbison/branch/master)
+![Build status](https://img.shields.io/github/check-runs/lexxmark/winflexbison/HEAD)
 
 # WinFlexBison - Flex and Bison for Windows
 


### PR DESCRIPTION
Instead of just the status of AppVeyor. AppVeyor does not even run in the main repository anymore.